### PR TITLE
Bug Fix: Corrected sca.py and reg_interface.py syntax errors

### DIFF
--- a/scripts/initOHv3b.sh
+++ b/scripts/initOHv3b.sh
@@ -33,8 +33,6 @@ FILE_GBT1=$3
 FILE_GBT2=$4
 FILE_FW=$5
 
-DIR_ORIG=$PWD
-
 # Check if input files exist
 if [ ! -f $FILE_GBT0 ]; then
     echo "Input file: ${FILE_GBT0} not found"
@@ -63,7 +61,6 @@ if [ ! -f $FILE_FW ]; then
 fi
 
 # Program GBT's
-cd ~/apps/reg_interface
 #for link in {0..11..1}
 for link in 0 1 2 3 4 5 6 7 8 9 10 11
 do
@@ -78,10 +75,10 @@ do
 done
 
 # Issue an sca reset
-sca.py $OHMASK r
+sca.py local $OHMASK r
 
 # Program the FPGA's
-sca.py $OHMASK program-fpga bit $FILE_FW
+sca.py local $OHMASK program-fpga bit $FILE_FW
 
 if [[ $FILE_FW =~ (([0-9a-fA-F]+)\.){3}([Bb]\.) ]]; then
     # OHv3b
@@ -100,7 +97,7 @@ else
     #    fi
     #done
 
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
 fi
 
 # Link reset
@@ -108,8 +105,5 @@ reg_interface.py -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
 
 # TU invert (forget for which FW versions this is required...)
 #reg_interface.py -e write "GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
-
-# Return to original directory
-cd $DIR_ORIG
 
 echo "Completed, Your OH's are ready to use"

--- a/scripts/initOHv3b_NoGBTs.sh
+++ b/scripts/initOHv3b_NoGBTs.sh
@@ -24,8 +24,6 @@ fi
 OHMASK=$1
 FILE_FW=$2
 
-DIR_ORIG=$PWD
-
 # Check if input files exist
 if [ ! -f $FILE_FW ]; then
     echo "Input file: ${FILE_FW} not found"
@@ -34,14 +32,14 @@ if [ ! -f $FILE_FW ]; then
 fi
 
 # Issue an sca reset
-sca.py $OHMASK r
+sca.py local $OHMASK r
 
 # Program the FPGA's
-sca.py $OHMASK program-fpga bit $FILE_FW
+sca.py local $OHMASK program-fpga bit $FILE_FW
 
 if [[ $FILE_FW =~ (([0-9a-fA-F]+)\.){3}([Bb]\.) ]]; then
     # OHv3b
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 1"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 1"
 else
     # OHv3a
     # Necessary for FW versions pre-dating v3.1.0.B
@@ -56,16 +54,13 @@ else
     #    fi
     #done
 
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
 fi
 
 # Link reset
-reg_interface --execute="write GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
+reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
 
 # TU invert (forget for which FW versions this is required...)
-#reg_interface --execute="write GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
-
-# Return to original directory
-cd $DIR_ORIG
+#reg_interface.py --execute="write GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
 
 echo "Completed, Your OH's are ready to use"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a bug in how `sca.py` and `reg_interface.py` were being called in the `initOHv3` scripts.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Caused crashes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Programmed two OHv3's via the init scripts.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
