### PR TITLE
New Feature: Adding PYTHONPATH to bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -23,6 +23,7 @@ alias l='ls $LS_OPTIONS -lA'
 #export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
+export PYTHONPATH=/mnt/persistent/gemdaq/python/reg_interface:$PYTHONPATH
 
 [ -z "$PS1" ] && return
 


### PR DESCRIPTION
User was unable to use python API on the card.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a line setting the `PYTHONPATH` to the `.bashrc`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Users where unable, as `gemuser`, to use the python API or test scripts without first placing them under the `/mnt/persistent/gemdaq` area.  To prevent propagation of admin password or modification of the `gemdaq` area by a novice user this change should enable the python API and set the correct `$env`.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Without setting `PYTHONPATH`:

```python
Python 2.7.9 (default, Apr 29 2016, 10:47:05) 
[GCC 4.9.2 20140904 (prerelease)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import rw_reg
ImportError: No module named rw_reg
>>> 
```

With setting `PYTHONPATH`:

```python
Python 2.7.9 (default, Apr 29 2016, 10:47:05) 
[GCC 4.9.2 20140904 (prerelease)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import rw_reg
>>> 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
