### PR TITLE
add a script which writes the nominal DAC values to the ctp7 config files

### DIFF
--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -68,6 +68,6 @@ for reg in nominal_DAC_value_files.keys():
                 print str(vfat)+ ": "+str(value)
             
             if args.dry_run:
-                os.system("sed -i '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")
+                os.system("sed '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")
             else:  
-                os.system("sed '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")    
+                os.system("sed -i '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")  

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -5,7 +5,7 @@ import argparse
 parser = argparse.ArgumentParser(description='Arguments to supply to write_DAC_values.py')
 
 parser.add_argument('OH', type=str, help="OH number", metavar='OH')
-parser.add_argument('nominalDacFileList', type=str, help="Name of a file containing a list of register names and NominalDACValues.txt files. Format:register_name1 <space> /path/to/nominal/DAC/file1 <newline> register_name2 <space> /path/to/nominal/DAC/file2 <newline> ... "), metavar='nominalDacFileList')
+parser.add_argument('nominalDacFileList', type=str, help="Name of a file containing a list of register names and NominalDACValues.txt files. Format:register_name1 <space> /path/to/nominal/DAC/file1 <newline> register_name2 <space> /path/to/nominal/DAC/file2 <newline> ... ", metavar='nominalDacFileList')
 parser.add_argument('--dry_run', dest='dry_run', action='store_true', help="If this flag is set the script will not overwrite the vfat3 config files.")
 
 args = parser.parse_args()

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -63,6 +63,6 @@ for reg in nominal_DAC_value_files.keys():
                 print str(vfat)+ ": "+str(value)
             
             if args.dry_run:
-                os.system("sed '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")
+                os.system("sed '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+"_cal.txt")
             else:  
-                os.system("sed -i '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")  
+                os.system("sed -i '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+"_cal.txt")  

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -1,0 +1,73 @@
+import os
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Arguments to supply to write_DAC_values.py')
+
+parser.add_argument('OH', type=str, help="OH number", metavar='OH')
+parser.add_argument('nominalDacFileList', type=str, help="Name of a file containing a list of register names and NominalDACValues.txt files", metavar='nominalDacFileList')
+parser.add_argument('--dry_run', dest='dry_run', action='store_true', help="If this flag is set the script will not overwrite the vfat3 config files. Format:register_name1 <space> /path/to/nominal/DAC/file1 <newline> register_name2 <space> /path/to/nominal/DAC/file2 <newline> ... ")
+
+args = parser.parse_args()
+
+#values copied from https://github.com/cms-gem-daq-project/cmsgemos/blob/generic-amc-RPC-v3-short-term/gempython/tools/amc_user_functions_xhal.py#L14-L43
+max_DAC_values = {
+            "BIAS_PRE_I_BIT": 0xff,
+            "BIAS_PRE_I_BLCC": 0x3f,
+            "BIAS_SH_I_BFCAS": 0xff,
+            "BIAS_SH_I_BDIFF": 0xff,
+            "BIAS_SD_I_BDIFF": 0xff,
+            "BIAS_SD_I_BFCAS": 0xff,
+            "BIAS_SD_I_BSF": 0x3f,
+            "BIAS_CFD_DAC_1": 0x3f,
+            "BIAS_CFD_DAC_2": 0x3f,
+            "HYST": 0x3f,
+            "THR_ARM_DAC": 0xff,
+            "THR_ZCC_DAC": 0xff,
+            "BIAS_PRE_VREF": 0xff,
+            "THR_ARM_DAC": 0xff,
+            "THR_ZCC_DAC": 0xff,
+            "ADC_VREF": 0x3
+            }
+
+nominal_DAC_value_files = {}
+
+for line in open(args.nominalDacFileList):
+    if line[0] == "#":
+        continue
+    line = line.strip(' ').strip('\n')
+    first = line.split(' ')[0].strip(' ')
+    second = line.split(' ')[1].strip(' ')
+
+    if first not in max_DAC_values.keys():
+        print('Warning: no maximum value found for register: '+first)
+    
+    nominal_DAC_value_files[first] = second
+
+print nominal_DAC_value_files
+    
+for reg in nominal_DAC_value_files.keys():
+    print "setting register "+str(reg)
+    print nominal_DAC_value_files[reg]
+    fname=nominal_DAC_value_files[reg]
+    print fname.split('/')[len(fname.split('/'))-1]
+    
+    f = open(nominal_DAC_value_files[reg])
+    for line in f:
+        vfat=int(line.split('\t')[0])
+        value=int(line.split('\t')[1])
+
+        if value < 0:
+            value = 0
+
+        if vfat not in [11,12]:     
+            if reg in max_DAC_values.keys() and value > max_DAC_values[reg]:
+                print str(vfat) +": "+ str(value) +" --> " + str(max_DAC_values[reg])
+                value = max_DAC_values[reg]
+            else:
+                print str(vfat)+ ": "+str(value)
+            
+            if args.dry_run:
+                os.system("sed -i '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")
+            else:  
+                os.system("sed '/^"+reg+"/{s/ [0-9]\+/ "+str(value)+"/;}' /mnt/persistent/gemdaq/vfat3/config_OH"+str(args.OH)+"_VFAT"+str(vfat)+".txt")    

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -47,11 +47,8 @@ for line in open(args.nominalDacFileList):
 print nominal_DAC_value_files
     
 for reg in nominal_DAC_value_files.keys():
-    print "setting register "+str(reg)
-    print nominal_DAC_value_files[reg]
+    print "setting the register "+str(reg)+ " using the file:"+nominal_DAC_value_files[reg]
     fname=nominal_DAC_value_files[reg]
-    print fname.split('/')[len(fname.split('/'))-1]
-    
     f = open(nominal_DAC_value_files[reg])
     for line in f:
         vfat=int(line.split('\t')[0])

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -44,8 +44,6 @@ for line in open(args.nominalDacFileList):
     
     nominal_DAC_value_files[first] = second
 
-print nominal_DAC_value_files
-    
 for reg in nominal_DAC_value_files.keys():
     print "setting the register "+str(reg)+ " using the file:"+nominal_DAC_value_files[reg]
     fname=nominal_DAC_value_files[reg]

--- a/scripts/write_DAC_values.py
+++ b/scripts/write_DAC_values.py
@@ -5,8 +5,8 @@ import argparse
 parser = argparse.ArgumentParser(description='Arguments to supply to write_DAC_values.py')
 
 parser.add_argument('OH', type=str, help="OH number", metavar='OH')
-parser.add_argument('nominalDacFileList', type=str, help="Name of a file containing a list of register names and NominalDACValues.txt files", metavar='nominalDacFileList')
-parser.add_argument('--dry_run', dest='dry_run', action='store_true', help="If this flag is set the script will not overwrite the vfat3 config files. Format:register_name1 <space> /path/to/nominal/DAC/file1 <newline> register_name2 <space> /path/to/nominal/DAC/file2 <newline> ... ")
+parser.add_argument('nominalDacFileList', type=str, help="Name of a file containing a list of register names and NominalDACValues.txt files. Format:register_name1 <space> /path/to/nominal/DAC/file1 <newline> register_name2 <space> /path/to/nominal/DAC/file2 <newline> ... "), metavar='nominalDacFileList')
+parser.add_argument('--dry_run', dest='dry_run', action='store_true', help="If this flag is set the script will not overwrite the vfat3 config files.")
 
 args = parser.parse_args()
 


### PR DESCRIPTION
After calculating the nominal DAC values using https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/develop/anaDACScan.py and https://github.com/cms-gem-daq-project/vfatqc-python-scripts/blob/rpc-playground/dacScanV3.py, we need to write them to config files on the ctp7. This script does this automatically. 

## Description
The user of this script supplies an OH number and a text file containing a list of register/nominal DAC value filename pairs. The script will then overwrite the config files in /mnt/persistent/gemdaq/vfat3/ with DAC values in these nominal DAC value files. The nominal DAC values files should be in the format that is output from https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/develop/anaDACScan.py.

If the nominal DAC value is less than 0, it is replaced by 0, and if the nominal DAC value is greater than the maximum register value in https://github.com/cms-gem-daq-project/cmsgemos/blob/generic-amc-RPC-v3-short-term/gempython/tools/amc_user_functions_xhal.py, it is replaced by the maximum register value.

The script must be run as a user which has permission to overwrite the config files.

The output of the script reports each of the values that is written, and whether the value in the input file is replaced due to being too large.

Example of nominalDacFileList:
```
BIAS_PRE_I_BIT /path/2018.10.17.09.34/NominalDACValues.txt
BIAS_PRE_I_BLCC /path/2018.10.17.09.28/NominalDACValues.txt
BIAS_SH_I_BFCAS /path/2018.10.17.09.29/NominalDACValues.txt
BIAS_SH_I_BDIFF /path/2018.10.16.10.33/NominalDACValues.txt
BIAS_SD_I_BDIFF /path/2018.10.16.10.34/NominalDACValues.txt
BIAS_SD_I_BFCAS /path/2018.10.16.10.35/NominalDACValues.txt
BIAS_SD_I_BSF /path/2018.10.17.09.31/NominalDACValues.txt
BIAS_CFD_DAC_1 /path/2018.10.16.10.37/NominalDACValues.txt
BIAS_CFD_DAC_2 /path/2018.10.17.09.32/NominalDACValues.txt
HYST /path/2018.10.17.13.28/NominalDACValues.txt
BIAS_PRE_VREF /path/2018.10.16.10.40/NominalDACValues.txt
```

Help information:
```
[amlevin@gem904daq01 scripts]$ python write_DAC_values.py -h
usage: write_DAC_values.py [-h] [--dry_run] OH nominalDacFileList

Arguments to supply to write_DAC_values.py

positional arguments:
  OH                  OH number
  nominalDacFileList  Name of a file containing a list of register names and
                      NominalDACValues.txt files. Format:register_name1
                      <space> /path/to/nominal/DAC/file1 <newline>
                      register_name2 <space> /path/to/nominal/DAC/file2
                      <newline> ...

optional arguments:
  -h, --help          show this help message and exit
  --dry_run           If this flag is set the script will not overwrite the
                      vfat3 config files.
```

Example execution command:
```
python write_DAC_values.py 3 nominal_dac_value_files.txt
```

Output example:
```
setting the register BIAS_CFD_DAC_1 using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.16.10.37/NominalDACValues.txt
0: 32
1: 31
2: 35
3: 28
4: 31
5: 32
6: 32
7: 32
8: 29
9: 36
10: 36
13: 27
14: 29
15: 27
16: 31
17: 32
18: 32
19: 34
20: 30
21: 35
22: 31
23: 33
setting the register HYST using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.13.28/NominalDACValues.txt
0: 3
1: 6
2: 0
3: 0
4: 1
5: 4
6: 6
7: 3
8: 0
9: 0
10: 0
13: 3
14: 0
15: 1
16: 2
17: 1
18: 0
19: 0
20: 1
21: 7
22: 2
23: 6
setting the register BIAS_SD_I_BFCAS using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.16.10.35/NominalDACValues.txt
0: 225
1: 243
2: 260 --> 255
3: 221
4: 207
5: 104
6: 226
7: 237
8: 230
9: 232
10: 251
13: 222
14: 228
15: 200
16: 257 --> 255
17: 248
18: 223
19: 251
20: 210
21: 239
22: 237
23: 251
setting the register BIAS_CFD_DAC_2 using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.09.32/NominalDACValues.txt
0: 40
1: 37
2: 34
3: 35
4: 34
5: 40
6: 34
7: 34
8: 34
9: 36
10: 33
13: 33
14: 37
15: 36
16: 36
17: 33
18: 31
19: 34
20: 36
21: 42
22: 37
23: 40
setting the register BIAS_SH_I_BDIFF using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.16.10.33/NominalDACValues.txt
0: 155
1: 144
2: 140
3: 132
4: 122
5: 67
6: 110
7: 123
8: 126
9: 149
10: 142
13: 147
14: 159
15: 112
16: 132
17: 125
18: 50
19: 143
20: 125
21: 132
22: 130
23: 126
setting the register BIAS_PRE_I_BLCC using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.09.28/NominalDACValues.txt
0: 25
1: 30
2: 22
3: 23
4: 23
5: 33
6: 28
7: 25
8: 21
9: 19
10: 15
13: 22
14: 24
15: 21
16: 27
17: 19
18: 8
19: 14
20: 22
21: 32
22: 19
23: 29
setting the register BIAS_SD_I_BSF using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.09.31/NominalDACValues.txt
0: 15
1: 15
2: 13
3: 15
4: 14
5: 16
6: 15
7: 14
8: 13
9: 13
10: 11
13: 14
14: 13
15: 14
16: 15
17: 13
18: 10
19: 11
20: 13
21: 16
22: 14
23: 15
setting the register BIAS_PRE_I_BIT using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.09.34/NominalDACValues.txt
0: 220
1: 228
2: 221
3: 206
4: 222
5: 226
6: 216
7: 206
8: 200
9: 218
10: 194
13: 216
14: 229
15: 214
16: 229
17: 221
18: 200
19: 232
20: 215
21: 214
22: 214
23: 223
setting the register BIAS_PRE_VREF using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.16.10.40/NominalDACValues.txt
0: 80
1: 80
2: 78
3: 81
4: 77
5: 82
6: 79
7: 80
8: 81
9: 83
10: 78
13: 81
14: 76
15: 78
16: 83
17: 79
18: 0
19: 78
20: 78
21: 80
22: 75
23: 76
setting the register BIAS_SH_I_BFCAS using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.17.09.29/NominalDACValues.txt
0: 267 --> 255
1: 312 --> 255
2: 255
3: 253
4: 278 --> 255
5: 129
6: 276 --> 255
7: 288 --> 255
8: 283 --> 255
9: 258 --> 255
10: 232
13: 250
14: 283 --> 255
15: 311 --> 255
16: 285 --> 255
17: 257 --> 255
18: 238
19: 286 --> 255
20: 275 --> 255
21: 305 --> 255
22: 241
23: 276 --> 255
setting the register BIAS_SD_I_BDIFF using the file:/mnt/persistent/texas/NominalDACValues_GE11-X-S-INDIA-0002/2018.10.16.10.34/NominalDACValues.txt
0: 266 --> 255
1: 263 --> 255
2: 244
3: 244
4: 269 --> 255
5: 120
6: 256 --> 255
7: 305 --> 255
8: 270 --> 255
9: 263 --> 255
10: 252
13: 266 --> 255
14: 247
15: 236
16: 260 --> 255
17: 275 --> 255
18: 157
19: 296 --> 255
20: 238
21: 215
22: 254
23: 264 --> 255
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
It is boring and error-prone to edit 24 files by hand.

## How Has This Been Tested?
I used a hardcoded version of this script to write the nominal DAC vaues for OH 0 on eagle64.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
