### PR TITLE
Update replace_parameter.sh such that it can accept a filename argument

### DIFF
--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -35,29 +35,35 @@ do
             exit;;
     esac
 done
+shift $((OPTIND-1))
 unset OPTIND
 
-if [ -z ${FILENAME} ]; then
-    if [ -z ${3+x} ]
+REGISTER=$1
+LINK=$2
+VALUE=$3
+
+if [ -z ${LINK} ]
+then
+    echo 'No link supplied'
+    usage
+    exit
+fi
+
+if [ -z ${FILENAME} ]
+then
+    if [ -z ${VALUE} ]
     then
-	    usage
-        echo ""
-        echo "        The -f flag was not provided, so the first usage example above should be followed."
+        echo 'No value supplied'
+        usage
         exit
+    else
+        sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
     fi
-    REGISTER=$1
-    VALUE=$3
-    LINK=$2
-    sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
 else
-    if [ -z ${4+x} ]
+    if [ -f ${FILENAME} ]
     then
-	    usage
-        echo ""
-        echo "        The -f flag was provided, so the second usage example above should be followed."
-        exit
+        awk '{system("sed -i \"s|^'$REGISTER'.*|'$REGISTER'   "$2"|g\" /mnt/persistent/gemdaq/vfat3/config_OH'$LINK'_VFAT"$1"_cal.txt")}' $FILENAME
+    else
+        echo "File ${FILENAME} not found"
     fi
-    REGISTER=$2
-    LINK=$3
-    awk '{system("sed -i \"s|^'$REGISTER'.*|'$REGISTER'   "$2"|g\" /mnt/persistent/gemdaq/vfat3/config_OH'$LINK'_VFAT"$1"_cal.txt")}' $FILENAME
 fi

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -2,19 +2,18 @@
 
 usage() {
 
-    echo './replace_parameter.sh <REGISTER> <LINK> <VALUE>'
-	echo './replace_parameter.sh -f <FILENAME> <REGISTER> <LINK>'
-	echo ''
-	echo '	REGISTER - register to be updated dropping the "CFG_" substring'
-	echo ''
-	echo '	VALUE - value in decimal to be assigned to REGISTER'
+    echo './replace_parameter.sh [-f <FILENAME>] <REGISTER> <LINK> <VALUE>'
+    echo ''
+    echo '	REGISTER - register to be updated dropping the "CFG_" substring'
+    echo ''
+    echo '	VALUE - value in decimal to be assigned to REGISTER'
     echo ''
     echo '	FILENAME - name of a file containing a list of vfat number/value pairs'
-	echo ''
-	echo '	Examples:'
-	echo ''
-	echo '		./replace_parameter.sh PULSE_STRETCH 1 4'
-	echo '		./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1'
+    echo ''
+    echo '	Examples:'
+    echo ''
+    echo '		./replace_parameter.sh PULSE_STRETCH 1 4'
+    echo '		./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1'
     kill -INT $$
 }
 

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -1,27 +1,55 @@
 #!/bin/bash
 
 usage() {
-	echo './replace_parameter.sh <REGISTER> <VALUE> <LINK>'
+
+	echo './replace_parameter.sh [-f] <REGISTER> <LINK> <VALUE/FILENAME>'
 	echo ''
 	echo '	REGISTER - register to be updated dropping the "CFG_" substring'
 	echo ''
-	echo '	VALUE - value in decimal to be assigned to REGISTER'
+	echo '	VALUE/FILENAME - value in decimal to be assigned to REGISTER or, if the -f option is used, filename containing a list of vfat number/ value pairs'
 	echo ''
-	echo '	Example:'
+	echo '	Examples:'
 	echo ''
 	echo '		./replace_parameter.sh PULSE_STRETCH 4 1'
-	echo ''
+	echo '		./replace_parameter.sh -f PULSE_STRETCH 4 /path/to/NominalDacValues.txt'
+	echo ''    
 
 	kill -INT $$; 
 }
 
-if [ -z ${3+x} ]
-then
-	usage
+ISFILE=0;
+OPTIND=1
+while getopts "fwhd" opts
+do
+    case $opts in
+        f)
+            ISFILE=1;;
+        h)
+            usage;;
+        \?)
+            usage;;
+        [?])
+            usage;;
+    esac
+done
+unset OPTIND
+
+if (($ISFILE == 1)); then
+    if [ -z ${4+x} ]
+    then
+	    usage
+    fi
+    REGISTER=$2
+    LINK=$3
+    FILENAME=$4
+    awk '{system("sed -i \"s|^'$REGISTER'.*|'$REGISTER'   "$2"|g\" /mnt/persistent/gemdaq/vfat3/config_OH'$LINK'_VFAT"$1"_cal.txt")}' $FILENAME
+else
+    if [ -z ${3+x} ]
+    then
+	    usage
+    fi
+    REGISTER=$1
+    LINK=$2
+    VALUE=$3
+    sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
 fi
-
-REGISTER=$1
-VALUE=$2
-LINK=$3
-
-sed -i "s|.*${REGISTER}.*|${REGISTER}	${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -12,9 +12,6 @@ usage() {
 	echo ''
 	echo '		./replace_parameter.sh PULSE_STRETCH 4 1'
 	echo '		./replace_parameter.sh -f PULSE_STRETCH 4 /path/to/NominalDacValues.txt'
-	echo ''    
-
-	kill -INT $$; 
 }
 
 ISFILE=0;
@@ -25,11 +22,14 @@ do
         f)
             ISFILE=1;;
         h)
-            usage;;
+            usage
+            exit;;
         \?)
-            usage;;
+            usage
+            exit;;
         [?])
-            usage;;
+            usage
+            exit;;
     esac
 done
 unset OPTIND
@@ -38,6 +38,8 @@ if (($ISFILE == 1)); then
     if [ -z ${4+x} ]
     then
 	    usage
+        echo "The -f flag was used, so the third argument should be a filename."
+        exit
     fi
     REGISTER=$2
     LINK=$3
@@ -47,6 +49,8 @@ else
     if [ -z ${3+x} ]
     then
 	    usage
+        echo "The -f flag was not used, so the third argument should be a value."
+        exit
     fi
     REGISTER=$1
     LINK=$2

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -2,25 +2,28 @@
 
 usage() {
 
-	echo './replace_parameter.sh [-f] <REGISTER> <LINK> <VALUE/FILENAME>'
+    echo './replace_parameter.sh <REGISTER> <VALUE> <LINK>'
+	echo './replace_parameter.sh -f <FILENAME> <REGISTER> <LINK>'
 	echo ''
 	echo '	REGISTER - register to be updated dropping the "CFG_" substring'
 	echo ''
-	echo '	VALUE/FILENAME - value in decimal to be assigned to REGISTER or, if the -f option is used, filename containing a list of vfat number/ value pairs'
+	echo '	VALUE - value in decimal to be assigned to REGISTER'
+    echo ''
+    echo '	FILENAME - name of a file containing a list of vfat number/value pairs'
 	echo ''
 	echo '	Examples:'
 	echo ''
 	echo '		./replace_parameter.sh PULSE_STRETCH 4 1'
-	echo '		./replace_parameter.sh -f PULSE_STRETCH 4 /path/to/NominalDacValues.txt'
+	echo '		./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1'
 }
 
 ISFILE=0;
 OPTIND=1
-while getopts "fwhd" opts
+while getopts "f:h" opts
 do
     case $opts in
         f)
-            ISFILE=1;;
+            FILENAME=$OPTARG;;
         h)
             usage
             exit;;
@@ -34,26 +37,27 @@ do
 done
 unset OPTIND
 
-if (($ISFILE == 1)); then
+if [ -z ${FILENAME} ]; then
+    if [ -z ${3+x} ]
+    then
+	    usage
+        echo ""
+        echo "        The -f flag was not provided, so the first usage example above should be followed."
+        exit
+    fi
+    REGISTER=$1
+    VALUE=$2
+    LINK=$3
+    sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
+else
     if [ -z ${4+x} ]
     then
 	    usage
-        echo "The -f flag was used, so the third argument should be a filename."
+        echo ""
+        echo "        The -f flag was provided, so the second usage example above should be followed."
         exit
     fi
     REGISTER=$2
     LINK=$3
-    FILENAME=$4
     awk '{system("sed -i \"s|^'$REGISTER'.*|'$REGISTER'   "$2"|g\" /mnt/persistent/gemdaq/vfat3/config_OH'$LINK'_VFAT"$1"_cal.txt")}' $FILENAME
-else
-    if [ -z ${3+x} ]
-    then
-	    usage
-        echo "The -f flag was not used, so the third argument should be a value."
-        exit
-    fi
-    REGISTER=$1
-    LINK=$2
-    VALUE=$3
-    sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
 fi

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -15,6 +15,7 @@ usage() {
 	echo ''
 	echo '		./replace_parameter.sh PULSE_STRETCH 1 4'
 	echo '		./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1'
+    kill -INT $$
 }
 
 ISFILE=0;
@@ -25,14 +26,11 @@ do
         f)
             FILENAME=$OPTARG;;
         h)
-            usage
-            exit;;
+            usage;;
         \?)
-            usage
-            exit;;
+            usage;;
         [?])
-            usage
-            exit;;
+            usage;;
     esac
 done
 shift $((OPTIND-1))
@@ -46,7 +44,6 @@ if [ -z ${LINK} ]
 then
     echo 'No link supplied'
     usage
-    exit
 fi
 
 if [ -z ${FILENAME} ]
@@ -55,7 +52,6 @@ then
     then
         echo 'No value supplied'
         usage
-        exit
     else
         sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
     fi

--- a/scripts/replace_parameter.sh
+++ b/scripts/replace_parameter.sh
@@ -2,7 +2,7 @@
 
 usage() {
 
-    echo './replace_parameter.sh <REGISTER> <VALUE> <LINK>'
+    echo './replace_parameter.sh <REGISTER> <LINK> <VALUE>'
 	echo './replace_parameter.sh -f <FILENAME> <REGISTER> <LINK>'
 	echo ''
 	echo '	REGISTER - register to be updated dropping the "CFG_" substring'
@@ -13,7 +13,7 @@ usage() {
 	echo ''
 	echo '	Examples:'
 	echo ''
-	echo '		./replace_parameter.sh PULSE_STRETCH 4 1'
+	echo '		./replace_parameter.sh PULSE_STRETCH 1 4'
 	echo '		./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1'
 }
 
@@ -46,8 +46,8 @@ if [ -z ${FILENAME} ]; then
         exit
     fi
     REGISTER=$1
-    VALUE=$2
-    LINK=$3
+    VALUE=$3
+    LINK=$2
     sed -i "s|^${REGISTER}.*|${REGISTER}   ${VALUE}|g" /mnt/persistent/gemdaq/vfat3/config_OH${LINK}_VFAT*_cal.txt
 else
     if [ -z ${4+x} ]


### PR DESCRIPTION
The current implementation of replace_parameter.sh will replace a parameter in all VFAT config files with a single value. My pull request replaces the parameter based on the contents of a text file, which can have different values for each VFAT.

## Description
When `-f` is passed to the script, the first argument is interpreted as a filename. The filename is expected to contain a list of vfatN value pairs, and the script will replace the value in the config file for vfatN for each pair.

The existing functionality of the script is maintained (however, I found that the current sed syntax incorrectly matches both the `HYST` and `EN_HYST` lines, so I fixed that).

Usage:
```
./replace_parameter.sh <REGISTER> <VALUE> <LINK>
./replace_parameter.sh -f <FILENAME> <REGISTER> <LINK>

        REGISTER - register to be updated dropping the "CFG_" substring

        VALUE - value in decimal to be assigned to REGISTER

        FILENAME - name of a file containing a list of vfat number/value pairs

        Examples:

                ./replace_parameter.sh PULSE_STRETCH 4 1
                ./replace_parameter.sh -f /path/to/NominalDacValues.txt PULSE_STRETCH 1
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
anaDACScan.py (https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/develop/anaDACScan.py) outputs a text file of vfatN value pairs which need to be set on the ctp7. 

## How Has This Been Tested?
Yes, I have tested the script on eagle64 to replace the `HYST` parameter for OH 0.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
