### PR TITLE
fixed gth config scripts to take into account miniPOD links and fix OH10 link0

### DIFF
--- a/scripts/gth_config_opto.sh
+++ b/scripts/gth_config_opto.sh
@@ -31,7 +31,7 @@ do
 	then
 
 		printf "Applying special inverted RX channel config for GTH CH#$i...\n"
-		mpoke $((gth_ctrl_ch0_base_addr+256*11)) $data_ch_inverted
+		mpoke $gth_ctrl_addr $data_ch_inverted
 	else
 		#printf "Normal config for $i\n"
 		#Apply standard, regular channel config

--- a/scripts/gth_config_opto_tx_inverted.sh
+++ b/scripts/gth_config_opto_tx_inverted.sh
@@ -31,7 +31,7 @@ do
 	then
 
 		printf "Applying special inverted RX channel config for GTH CH#$i...\n"
-		mpoke $((gth_ctrl_ch0_base_addr+256*11)) $data_ch_inverted
+		mpoke $gth_ctrl_addr $data_ch_inverted
 	else
 		#printf "Normal config for $i\n"
 		#Apply standard, regular channel config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When we started using miniPOD links for trigger inputs in v3.7.2, Laurent noticed that OH10 link0 was not working, this was traced to a bug introduced long time ago which resulted in two miniPOD channels to not be configured at all (those are one of few channels that need RX inversion), so they defaulted to powered-off state. One of those two channels is unused, and the other one is OH10 link0.

## Description
<!--- Describe your changes in detail -->

The fix is very simple -- use the actual address of the channel instead of hardcoded channel 11 address (which was the only one needing RX inversion before miniPOD links were introduced).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
OH10 link0 is not working without this fix
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Trigger loopback setup at TAMU. Laurent will test this with real hardware.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
