### PR TITLE
add script to switch between v2 and v3

### DIFF
--- a/scripts/vX_switch.sh
+++ b/scripts/vX_switch.sh
@@ -1,0 +1,30 @@
+usage() { 
+
+    echo './vX_switch.sh [vX]'
+    echo ''
+    echo '    vX = v2 or v3'
+    echo ''
+    echo 'Will change the symlinks on the ctp7 to point to the correct files for vX electronics. Ends with a call to recover.sh'
+    kill -INT $$
+}
+
+VX=$1
+
+if [ -z ${1+x} ]
+then
+    usage
+fi
+
+if [ $VX != "v2" ]  &&  [ $VX != "v3" ]
+then
+    usage
+fi   
+
+echo "Updating symlinks"
+ln -s /mnt/persistent/gemdaq_${VX}/ /mnt/persistent/gemuser/gemdaq_USER
+ln -s /mnt/persistent/rpcmodules_${VX}/ /mnt/persistent/gemuser/rpcmodules_USER
+echo "Finished symlinks"
+
+echo "Running recover.sh"
+recover.sh
+echo "Finished running recover.sh"

--- a/scripts/vX_switch.sh
+++ b/scripts/vX_switch.sh
@@ -21,8 +21,8 @@ then
 fi   
 
 echo "Updating symlinks"
-ln -s /mnt/persistent/gemdaq_${VX}/ /mnt/persistent/gemuser/gemdaq_USER
-ln -s /mnt/persistent/rpcmodules_${VX}/ /mnt/persistent/gemuser/rpcmodules_USER
+ln -snf /mnt/persistent/gemdaq_${VX} /mnt/persistent/gemuser/gemdaq_USER
+ln -snf /mnt/persistent/rpcmodules_${VX} /mnt/persistent/gemuser/rpcmodules_USER
 echo "Finished symlinks"
 
 echo "Running recover.sh"


### PR DESCRIPTION
Script to seamlessly switch between v2 and v3 on a ctp7.

## Description
This script takes a single argument `v2` or `v3` and will change the symlinks `/mnt/persistent/gemuser/gemdaq_USER` and `/mnt/persistent/gemuser/rpcmodules_USER` based on this argument. It ends with a call to `recover.sh`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
eagle34 is supporting both a v2 and a v3 detector.

## How Has This Been Tested?

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
