### PR TITLE
[Maintenance]: will now obtain the gemloader scripts per CTP7 version

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -23,6 +23,7 @@ alias l='ls $LS_OPTIONS -lA'
 #export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
+export PYTHONPATH=/mnt/persistent/gemdaq/python/reg_interface:$PYTHONPATH
 
 [ -z "$PS1" ] && return
 

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -3,3 +3,4 @@
 # Except this file
 !.gitignore
 !*.sh
+!*.py

--- a/scripts/gth_config_opto.sh
+++ b/scripts/gth_config_opto.sh
@@ -31,7 +31,7 @@ do
 	then
 
 		printf "Applying special inverted RX channel config for GTH CH#$i...\n"
-		mpoke $((gth_ctrl_ch0_base_addr+256*11)) $data_ch_inverted
+		mpoke $gth_ctrl_addr $data_ch_inverted
 	else
 		#printf "Normal config for $i\n"
 		#Apply standard, regular channel config

--- a/scripts/gth_config_opto_tx_inverted.sh
+++ b/scripts/gth_config_opto_tx_inverted.sh
@@ -31,7 +31,7 @@ do
 	then
 
 		printf "Applying special inverted RX channel config for GTH CH#$i...\n"
-		mpoke $((gth_ctrl_ch0_base_addr+256*11)) $data_ch_inverted
+		mpoke $gth_ctrl_addr $data_ch_inverted
 	else
 		#printf "Normal config for $i\n"
 		#Apply standard, regular channel config

--- a/scripts/initOHv3b.sh
+++ b/scripts/initOHv3b.sh
@@ -33,8 +33,6 @@ FILE_GBT1=$3
 FILE_GBT2=$4
 FILE_FW=$5
 
-DIR_ORIG=$PWD
-
 # Check if input files exist
 if [ ! -f $FILE_GBT0 ]; then
     echo "Input file: ${FILE_GBT0} not found"
@@ -63,7 +61,6 @@ if [ ! -f $FILE_FW ]; then
 fi
 
 # Program GBT's
-cd ~/apps/reg_interface
 #for link in {0..11..1}
 for link in 0 1 2 3 4 5 6 7 8 9 10 11
 do
@@ -78,10 +75,10 @@ do
 done
 
 # Issue an sca reset
-sca.py $OHMASK r
+sca.py local $OHMASK r
 
 # Program the FPGA's
-sca.py $OHMASK program-fpga bit $FILE_FW
+sca.py local $OHMASK program-fpga bit $FILE_FW
 
 if [[ $FILE_FW =~ (([0-9a-fA-F]+)\.){3}([Bb]\.) ]]; then
     # OHv3b
@@ -100,7 +97,7 @@ else
     #    fi
     #done
 
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
 fi
 
 # Link reset
@@ -108,8 +105,5 @@ reg_interface.py -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
 
 # TU invert (forget for which FW versions this is required...)
 #reg_interface.py -e write "GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
-
-# Return to original directory
-cd $DIR_ORIG
 
 echo "Completed, Your OH's are ready to use"

--- a/scripts/initOHv3b_NoGBTs.sh
+++ b/scripts/initOHv3b_NoGBTs.sh
@@ -24,8 +24,6 @@ fi
 OHMASK=$1
 FILE_FW=$2
 
-DIR_ORIG=$PWD
-
 # Check if input files exist
 if [ ! -f $FILE_FW ]; then
     echo "Input file: ${FILE_FW} not found"
@@ -34,14 +32,14 @@ if [ ! -f $FILE_FW ]; then
 fi
 
 # Issue an sca reset
-sca.py $OHMASK r
+sca.py local $OHMASK r
 
 # Program the FPGA's
-sca.py $OHMASK program-fpga bit $FILE_FW
+sca.py local $OHMASK program-fpga bit $FILE_FW
 
 if [[ $FILE_FW =~ (([0-9a-fA-F]+)\.){3}([Bb]\.) ]]; then
     # OHv3b
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 1"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 1"
 else
     # OHv3a
     # Necessary for FW versions pre-dating v3.1.0.B
@@ -56,16 +54,13 @@ else
     #    fi
     #done
 
-    reg_interface --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
+    reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.VFAT3.USE_OH_V3B_MAPPING 0"
 fi
 
 # Link reset
-reg_interface --execute="write GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
+reg_interface.py --execute="write GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1"
 
 # TU invert (forget for which FW versions this is required...)
-#reg_interface --execute="write GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
-
-# Return to original directory
-cd $DIR_ORIG
+#reg_interface.py --execute="write GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT17_TU_INVERT 0x6"
 
 echo "Completed, Your OH's are ready to use"

--- a/scripts/setLinks.py
+++ b/scripts/setLinks.py
@@ -1,0 +1,16 @@
+#!/bin/env python
+
+if __name__ == '__main__': 
+    import os
+    
+    from optparse import OptionParser
+    
+    parser = OptionParser()
+    parser.add_option("-g", "--gtx", type="int", dest="gtx",
+            help="GTX on the AMC", metavar="gtx", default=0)
+    
+    (options, args) = parser.parse_args()
+    
+    for vfat in range(0,24):
+        os.system('cp /mnt/persistent/gemdaq/vfat3/conf.txt /mnt/persistent/gemdaq/vfat3/config_OH%i_VFAT%i_cal.txt'%(options.gtx,vfat))
+        os.system('ln -sf /mnt/persistent/gemdaq/vfat3/config_OH%i_VFAT%i_cal.txt /mnt/persistent/gemdaq/vfat3/config_OH%i_VFAT%i.txt'%(options.gtx,vfat,options.gtx,vfat))

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -186,8 +186,8 @@ then
             [yY]* )
                 echo "ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser}";
                 ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser} && /bin/save_passwd;
-                echo "rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/";
-                rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/;
+                echo "rsync -aXch --progress --partial --links .profile .bashrc .vimrc .inputrc ${newuser}@${ctp7host}:~/";
+                rsync -aXch --progress --partial --links .profile .bashrc .vimrc .inputrc ${newuser}@${ctp7host}:~/;
                 break;;
             [nN]* )
                 break;;

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -168,7 +168,7 @@ then
         case $create in
             [yY]* )
                 echo "ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser}";
-                ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser};
+                ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser} && save_passwd;
                 echo "rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/";
                 rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/;
                 break;;

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -119,7 +119,9 @@ if [ -n "${ge_gen}" ]
 then
     if [[ ${ge_gen} = "2" ]]
     then
-        usege21 = 1
+        ge21suf="ge21_"
+    else 
+        ge21suf=""
     fi
 fi
 
@@ -133,55 +135,29 @@ then
         ln -sf recover_v2.sh scripts/recover.sh
     fi
     # echo "creating links for CTP7 firmware version: ${ctpfw}"
-    if [ -n "${usege21}" ]
-    then 
-        if [ ! -f "fw/gem_ctp7_gem_ctp7_v${ctp7fw//./_}.bit" ]
-        then
-            echo "CTP7 firmware fw/gem_ctp7_v${ctp7fw//./_}.bit missing, downloading"
-            echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit"
-            wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit
-        fi
-        echo "ln -sf fw/gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit fw/gem_ctp7.bit"
-        ln -sf gem_ctp7_v${ctp7fw//./_}_ge21_${nlinks}oh.bit fw/gem_ctp7.bit
-        
-        if [ ! -f "xml/gem_amc_top_${ctp7fw//./_}.xml" ]
-        then
-            echo "CTP7 firmware xml/gem_amc_top_${ctp7fw//./_}.xml missing, downloading"
-            echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip"
-            wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip
-            echo "unzip address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip"
-            unzip address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip
-            echo "rm address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip"
-            rm address_table_v${ctp7fw//./_}_ge21_${nlinks}oh.zip
-            echo "cp address_table_v${ctp7fw//./_}_ge21_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml"
-            cp address_table_v${ctp7fw//./_}_ge21_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml
-            echo "rm -rf address_table_v${ctp7fw//./_}_ge21_${nlinks}oh"
-            rm -rf address_table_v${ctp7fw//./_}_ge21_${nlinks}oh
-        fi
-    else
-        if [ ! -f "fw/gem_ctp7_gem_ctp7_v${ctp7fw//./_}.bit" ]
-        then
-            echo "CTP7 firmware fw/gem_ctp7_v${ctp7fw//./_}.bit missing, downloading"
-            echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit"
-            wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit
-        fi
-        echo "ln -sf fw/gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit fw/gem_ctp7.bit"
-        ln -sf gem_ctp7_v${ctp7fw//./_}_${nlinks}oh.bit fw/gem_ctp7.bit
 
-        if [ ! -f "xml/gem_amc_top_${ctp7fw//./_}.xml" ]
-        then
-            echo "CTP7 firmware xml/gem_amc_top_${ctp7fw//./_}.xml missing, downloading"
-            echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_${nlinks}oh.zip"
-            wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_${nlinks}oh.zip
-            echo "unzip address_table_v${ctp7fw//./_}_${nlinks}oh.zip"
-            unzip address_table_v${ctp7fw//./_}_${nlinks}oh.zip
-            echo "rm address_table_v${ctp7fw//./_}_${nlinks}oh.zip"
-            rm address_table_v${ctp7fw//./_}_${nlinks}oh.zip
-            echo "cp address_table_v${ctp7fw//./_}_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml"
-            cp address_table_v${ctp7fw//./_}_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml
-            echo "rm -rf address_table_v${ctp7fw//./_}_${nlinks}oh"
-            rm -rf address_table_v${ctp7fw//./_}_${nlinks}oh
-        fi
+    if [ ! -f "fw/gem_ctp7_gem_ctp7_v${ctp7fw//./_}.bit" ]
+    then
+        echo "CTP7 firmware fw/gem_ctp7_v${ctp7fw//./_}.bit missing, downloading"
+        echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit"
+        wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit -O fw/gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit
+    fi
+    echo "ln -sf fw/gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit fw/gem_ctp7.bit"
+    ln -sf gem_ctp7_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.bit fw/gem_ctp7.bit
+        
+    if [ ! -f "xml/gem_amc_top_${ctp7fw//./_}.xml" ]
+    then
+        echo "CTP7 firmware xml/gem_amc_top_${ctp7fw//./_}.xml missing, downloading"
+        echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip"
+        wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip
+        echo "unzip address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip"
+        unzip address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip
+        echo "rm address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip"
+        rm address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh.zip
+        echo "cp address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml"
+        cp address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml
+        echo "rm -rf address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh"
+        rm -rf address_table_v${ctp7fw//./_}_${ge21suf}${nlinks}oh
     fi
 
     echo "Download gemloader"

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -153,6 +153,7 @@ then
     #wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip
     #unzip gemloader_v${ctp7fw//./_}.zip
     #rm -rf gemloader_v${ctp7fw//./_}.zip
+    # Temporary hack, above should hopefully be used once GEM_AMC releasing conforms
     echo "wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip"
     wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip
     unzip gemloader_v3_5_0.zip

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -165,14 +165,12 @@ then
     then
         mkdir gemloader
     fi
-    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_clear_header.sh -P gemloader/"
-    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_clear_header.sh -P gemloader/
-    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_configure.sh -P gemloader/"
-    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_configure.sh -P gemloader/
-    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_load_test_data.sh -P gemloader/"
-    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_load_test_data.sh -P gemloader/
-    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_read.sh -P gemloader/"
-    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_read.sh -P gemloader/
+    declare -a gemloaderArray=("gemloader_clear_header.sh" "gemloader_configure.sh" "gemloader_load_test_data.sh" "gemloader_read.sh")
+    for gemloaderFile in "${gemloaderArray[@]}"
+    do
+        echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw}/scripts/gemloader/${gemloaderFile} -P gemloader/"
+        wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw}/scripts/gemloader/${gemloaderFile} -P gemloader/
+    done
 
     echo "ln -sf xml/gem_amc_top_v${ctp7fw//./_}.xml xml/gem_amc_top.xml"
     ln -sf gem_amc_v${ctp7fw//./_}.xml xml/gem_amc_top.xml

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -70,24 +70,23 @@ then
     if [[ ${ohfw} = *"3."* ]]
     then 
         echo "Downloading V3 firmware with tag ${ohfw}"
-        echo "wget https://github.com/cms-gem-daq-project/OptoHybridv3/releases/download/${ohfw}/OH_20180320_${ohfw}.tar.gz"
-        wget https://github.com/cms-gem-daq-project/OptoHybridv3/releases/download/${ohfw}/OH_20180320_${ohfw}.tar.gz 
+        echo "wget https://github.com/cms-gem-daq-project/OptoHybridv3/releases/download/${ohfw}/OH_${ohfw}.tar.gz"
+        wget https://github.com/cms-gem-daq-project/OptoHybridv3/releases/download/${ohfw}/OH_${ohfw}.tar.gz 
         echo "Untar and copy firmware files and xml address table to relevant locations"
-        ohfw="20180320_"${ohfw}
         echo "tar -xvf OH_${ohfw}.tar.gz"
         tar -xvf OH_${ohfw}.tar.gz
         echo "cp OH_${ohfw}/OH_${ohfw}.mcs oh_fw/optohybrid_${ohfw}.mcs"
-        cp OH_${ohfw}/OH-${ohfw//_/-}.mcs oh_fw/optohybrid_${ohfw}.mcs
-        echo "cp OH_${ohfw}/OH-${ohfw//_/-}.bit oh_fw/optohybrid_${ohfw}.bit"
-        cp OH_${ohfw}/OH-${ohfw//_/-}.bit oh_fw/optohybrid_${ohfw}.bit
-        echo "cp OH_${ohfw}/optohybrid_registers.xml xml/optohybrid_registers_${ohfw}.xml"
-        cp OH_${ohfw}/optohybrid_registers.xml xml/optohybrid_registers_${ohfw}.xml
+        cp OH_${ohfw}/OH_${ohfw//_/-}.mcs oh_fw/optohybrid_${ohfw}.mcs
+        echo "cp OH_${ohfw}/OH_${ohfw//_/-}.bit oh_fw/optohybrid_${ohfw}.bit"
+        cp OH_${ohfw}/OH_${ohfw//_/-}.bit oh_fw/optohybrid_${ohfw}.bit
+        echo "cp OH_${ohfw}/oh_registers.xml xml/optohybrid_registers_${ohfw}.xml"
+        cp OH_${ohfw}/oh_registers_${ohfw}.xml xml/oh_registers_${ohfw}.xml
         echo "ln -sf optohybrid_${ohfw}.bit oh_fw/optohybrid_top.bit"
         ln -sf optohybrid_${ohfw}.bit oh_fw/optohybrid_top.bit
         echo "ln -sf optohybrid_${ohfw}.mcs oh_fw/optohybrid_top.mcs"
         ln -sf optohybrid_${ohfw}.mcs oh_fw/optohybrid_top.mcs
-        echo "ln -sf xml/optohybrid_registers_${ohfw}.mcs oh_fw/optohybrid_registers.xml"
-        ln -sf optohybrid_registers_${ohfw}.xml xml/optohybrid_registers.xml
+        echo "ln -sf xml/oh_registers_${ohfw}.mcs oh_fw/optohybrid_registers.xml"
+        ln -sf oh_registers_${ohfw}.xml xml/optohybrid_registers.xml
         echo "rm -rf OH_${ohfw}/"
         rm -rf OH_${ohfw}/
         echo "rm -rf OH_${ohfw}.tar.gz"
@@ -143,17 +142,21 @@ then
         unzip address_table_v${ctp7fw//./_}_${nlinks}oh.zip
         echo "rm address_table_v${ctp7fw//./_}_${nlinks}oh.zip"
         rm address_table_v${ctp7fw//./_}_${nlinks}oh.zip
-        echo "cp address_table_v_${ctp7fw//./_}/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml"
-        cp address_table_v_${ctp7fw//./_}/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml
-        echo "rm -rf address_table_v_${ctp7fw//./_}"
-        rm -rf address_table_v_${ctp7fw//./_}
+        echo "cp address_table_v${ctp7fw//./_}_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml"
+        cp address_table_v${ctp7fw//./_}_${nlinks}oh/gem_amc_top.xml xml/gem_amc_v${ctp7fw//./_}.xml
+        echo "rm -rf address_table_v${ctp7fw//./_}_${nlinks}oh"
+        rm -rf address_table_v${ctp7fw//./_}_${nlinks}oh
     fi
 
     echo "Download gemloader"
-    echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip"
-    wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip
-    unzip gemloader_v${ctp7fw//./_}.zip
-    rm -rf gemloader_v${ctp7fw//./_}.zip
+    #echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip"
+    #wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip
+    #unzip gemloader_v${ctp7fw//./_}.zip
+    #rm -rf gemloader_v${ctp7fw//./_}.zip
+    echo "wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip"
+    wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip
+    unzip gemloader_v3_5_0.zip
+    rm -rf gemloader_v3_5_0.zip
 
     echo "ln -sf xml/gem_amc_top_v${ctp7fw//./_}.xml xml/gem_amc_top.xml"
     ln -sf gem_amc_v${ctp7fw//./_}.xml xml/gem_amc_top.xml
@@ -168,7 +171,7 @@ then
         case $create in
             [yY]* )
                 echo "ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser}";
-                ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser} && save_passwd;
+                ssh root@${ctp7host} /usr/sbin/adduser ${newuser} -h /mnt/persistent/${newuser} && /bin/save_passwd;
                 echo "rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/";
                 rsync -aXch --progress --partial --links .profile .bashrc .viminfo .vimrc .inputrc ${newuser}@${ctp7host}:~/;
                 break;;
@@ -235,8 +238,14 @@ then
     find bin -type f -print0 | xargs -0 -n1 chmod a+rx
     find lib -type f -print0 | xargs -0 -n1 chmod a+rx
 
-    echo "rsync -ach --progress --partial --links bin fw lib oh_fw scripts xml python root@${ctp7host}:/mnt/persistent/gemdaq/"
-    rsync -ach --progress --partial --links bin fw lib oh_fw scripts xml python gemloader root@${ctp7host}:/mnt/persistent/gemdaq/
+    echo "wget https://raw.githubusercontent.com/cms-gem-daq-project/ctp7_modules/develop/conf/conf.txt"
+    wget https://raw.githubusercontent.com/cms-gem-daq-project/ctp7_modules/develop/conf/conf.txt
+    echo "cp conf.txt vfat3/conf.txt"
+    cp conf.txt vfat3/conf.txt
+    echo "rm -rf conf.txt"
+
+    echo "rsync -ach --progress --partial --links bin fw lib oh_fw scripts xml python vfat3 root@${ctp7host}:/mnt/persistent/gemdaq/"
+    rsync -ach --progress --partial --links bin fw lib oh_fw scripts xml python gemloader vfat3 root@${ctp7host}:/mnt/persistent/gemdaq/
    
     echo "Update LMDB address table on the CTP7, make a new .pickle file and resync xml folder"
     echo "cp xml/* $XHAL_ROOT/etc/"
@@ -257,6 +266,7 @@ then
 
     echo "Cleaning local temp folders"
     rm ./bin/*
+    rm ./vfat3/*
     rm ./lib/*
     rm ./fw/*
     rm ./oh_fw/*

--- a/setup_ctp7.sh
+++ b/setup_ctp7.sh
@@ -161,15 +161,18 @@ then
     fi
 
     echo "Download gemloader"
-    #echo "wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip"
-    #wget https://github.com/evka85/GEM_AMC/releases/download/v${ctp7fw}/gemloader_v${ctp7fw//./_}.zip
-    #unzip gemloader_v${ctp7fw//./_}.zip
-    #rm -rf gemloader_v${ctp7fw//./_}.zip
-    # Temporary hack, above should hopefully be used once GEM_AMC releasing conforms
-    echo "wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip"
-    wget https://github.com/evka85/GEM_AMC/releases/download/v3.5.0/gemloader_v3_5_0.zip
-    unzip gemloader_v3_5_0.zip
-    rm -rf gemloader_v3_5_0.zip
+    if [ ! -d "gemloader/" ]
+    then
+        mkdir gemloader
+    fi
+    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_clear_header.sh -P gemloader/"
+    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_clear_header.sh -P gemloader/
+    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_configure.sh -P gemloader/"
+    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_configure.sh -P gemloader/
+    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_load_test_data.sh -P gemloader/"
+    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_load_test_data.sh -P gemloader/
+    echo "wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_read.sh -P gemloader/"
+    wget https://raw.githubusercontent.com/evka85/GEM_AMC/v${ctp7fw//./_}/scripts/gemloader/gemloader_read.sh -P gemloader/
 
     echo "ln -sf xml/gem_amc_top_v${ctp7fw//./_}.xml xml/gem_amc_top.xml"
     ln -sf gem_amc_v${ctp7fw//./_}.xml xml/gem_amc_top.xml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removing hard coded `wget` to `3.5.0` gemloader scripts and now using the per tag scripts in the `GEM_AMC` repo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Previously we were using hard coded version to the 3.5.0 release.  Now we will always get the scripts from the tag associated with the release (unless @evka85 can ensure each release would include these files; which has not been the case thus far...relying on the tag seems to be more reliable).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested here: http://cmsonline.cern.ch/cms-elog/1086736

This PR reflects state after solving all issues.  Note that LMDB needs to still be updated by hand since the version of the libxhal_ctp7.so library in xhal tag 3.2.2 is horrifically out of date.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
