### PR TITLE
[hotfix] Fix `restart_ipbus.sh` fails to detect `ipbus`

### DIFF
--- a/scripts/restart_ipbus.sh
+++ b/scripts/restart_ipbus.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipbstatus=$(ps |grep [i]pbus)
+ipbstatus=$(ps |egrep 'ipbus$')
 
 if [ "$?" = "1" ]
 then


### PR DESCRIPTION
## Description
Fix #45

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
#45 

## How Has This Been Tested?
Fixed version has been in use in various cards.
